### PR TITLE
feat: promote sda-spring-boot-commons and MongoDB Operator

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,7 @@ We do that with a user centered approach and a platform featuring "all" the serv
 
 ### 🧑‍💻 How do we develop?
 We believe in quality, standards and modern architectures powered with and by open source software. We love 
-❤️ microservices and have first dates with microfrontends. With [sda-dropwizard-commons](https://github.com/SDA-SE/sda-dropwizard-commons) we published a toolset for building microservices and are actively contributing to [Backstage by spotify](https://github.com/backstage/backstage).  
+❤️ microservices and have first dates with microfrontends. With [sda-dropwizard-commons](https://github.com/SDA-SE/sda-dropwizard-commons) and [sda-spring-boot-commons](https://github.com/SDA-SE/sda-spring-boot-commons) we published toolsets for building microservices and are actively contributing to [Backstage by spotify](https://github.com/backstage/backstage). We built the [MongoDB Operator](https://github.com/SDA-SE/mongodb-operator) to [simplify deployments](https://medium.com/sda-se/kubernetes-operator-to-the-rescue-how-our-own-mongodb-operator-improved-our-deployments-6d5ba3324abc) in Kubernetes.
 
 ### 🫀 Our Culture
 Be an active part of the team and contribute your ideas & opinions. Our team language is english and we love hiring people with diverse backgrounds.


### PR DESCRIPTION
This PR adds information about our latest open source projects. Could you pin [sda-spring-boot-commons](https://github.com/SDA-SE/sda-spring-boot-commons) and [mongodb-operator](https://github.com/SDA-SE/mongodb-operator) in the public organization profile as well?